### PR TITLE
docs: docsify 기본 설정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Strangers On Subway
+# Strangers on Bus
+
 누군지 모르지만 내 옆에 있을 사람과 채팅하는 서비스
 
 [Slack](https://strangersonsubway.slack.com)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Headline
+
+> An awesome project.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,6 @@
-# Headline
+# Strangers on Bus
 
-> An awesome project.
+누군지 모르지만 내 옆에 있을 사람과 채팅하는 서비스
+
+[Slack](https://strangersonsubway.slack.com)
+[Figma](https://www.figma.com/files/team/1462005587373981919/project/326294968/Team-project?fuid=1462005585749641576)

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Document</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta name="description" content="Description">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    window.$docsify = {
+      name: 'Strangers on Bus',
+      repo: 'https://github.com/minimal1/strangers-on-bus'
+    }
+  </script>
+  <!-- Docsify v4 -->
+  <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+</body>
+</html>


### PR DESCRIPTION
# What
- 프로젝트 문서 정리를 위해 docsify라는 경량 문서화 서비스를 도입합니다.
- main 브랜치의 docs 디렉토리를 github page로 지원할 예정입니다.

## Reference
- https://docsify.js.org/#/