### PR TITLE
fix: 사이드바에서 Conventional Commit 링크 오타 수정

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -16,7 +16,7 @@
 
   - [Trunk Based Development](/culture/development/trunk-based-development.md)
   - [Branch naming](/culture/development/branch-naming.md)
-  - [Conventional Commit](/culture/development/convential-commit.md)
+  - [Conventional Commit](/culture/development/conventional-commit.md)
   - [Monorepo](/culture/development/monorepo.md)
   - [PR Format](/culture/development/pr-format.md)
 


### PR DESCRIPTION
## 변경 사항 설명
Docsify 사이드바에서 Conventional Commit 문서 링크의 오타를 수정했습니다:

- 잘못된 링크: `/culture/development/convential-commit.md` (오타: convential)
- 올바른 링크: `/culture/development/conventional-commit.md` (수정: conventional)

## 문제점
오타로 인해 문서 링크가 작동하지 않아 해당 문서에 접근할 수 없었습니다.

## 테스트 방법
1. PR이 병합된 후 문서 사이트에 접속
2. 사이드바에서 "Conventional Commit" 링크 클릭
3. 문서가 제대로 로드되는지 확인

## 체크리스트
- [x] 사이드바 링크 경로가 실제 파일 경로와 일치하는지 확인했습니다
- [x] 오타를 정확히 수정했습니다
- [x] 변경 사항이 다른 부분에 영향을 미치지 않습니다