### PR TITLE
chore: branch-naming.md 문서 제거

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -15,7 +15,6 @@
 - 개발 방식
 
   - [Trunk Based Development](/culture/development/trunk-based-development.md)
-  - [Branch naming](/culture/development/branch-naming.md)
   - [Conventional Commit](/culture/development/conventional-commit.md)
   - [Monorepo](/culture/development/monorepo.md)
   - [PR Format](/culture/development/pr-format.md)

--- a/docs/culture/development/branch-naming.md
+++ b/docs/culture/development/branch-naming.md
@@ -1,1 +1,0 @@
-# Branch naming 규칙


### PR DESCRIPTION
## 변경 사항 설명
`branch-naming.md` 파일을 제거했습니다. 이 파일은 현재 사용되지 않으며, 브랜치 이름 지정 규칙은 Trunk Based Development 문서에 충분히 설명되어 있습니다.

## 수행한 작업
1. `docs/culture/development/branch-naming.md` 파일 삭제
2. 사이드바에서 "Branch naming" 항목 제거

## 테스트 방법
1. PR이 병합된 후 문서 사이트에 접속
2. 사이드바에 "Branch naming" 항목이 더 이상 표시되지 않는지 확인
3. 해당 문서 링크로 직접 접근을 시도해도 404 오류가 발생하는지 확인

## 체크리스트
- [x] 필요 없는 파일을 제거했습니다
- [x] 사이드바에서 관련 링크를 제거했습니다
- [x] 변경사항이 다른 부분에 영향을 미치지 않습니다